### PR TITLE
Improve login component

### DIFF
--- a/src/Abp.Blazor.Server.RadzenUI/Abp.Blazor.Server.RadzenUI.csproj
+++ b/src/Abp.Blazor.Server.RadzenUI/Abp.Blazor.Server.RadzenUI.csproj
@@ -26,7 +26,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Radzen.Blazor" Version="8.4.1" />
+		<PackageReference Include="Radzen.Blazor" Version="8.4.2" />
 		<PackageReference Include="Volo.Abp.AspNetCore.Components.Server" Version="10.0.1" />
 		<PackageReference Include="Volo.Abp.Autofac" Version="10.0.1" />
 		<PackageReference Include="Volo.Abp.PermissionManagement.EntityFrameworkCore" Version="10.0.1" />

--- a/src/Abp.Blazor.Server.RadzenUI/Components/Pages/Account/Login.razor
+++ b/src/Abp.Blazor.Server.RadzenUI/Components/Pages/Account/Login.razor
@@ -1,5 +1,7 @@
 ﻿@page "/account/login"
 @using Abp.RadzenUI.Components.Layout
+@using Microsoft.AspNetCore.Authentication
+@using Microsoft.Extensions.Options
 @using Volo.Abp.Account.Localization
 @using Volo.Abp.Account.Settings
 @using Volo.Abp.AspNetCore.Components
@@ -9,21 +11,35 @@
 
 <PageTitle>@L["Login"]</PageTitle>
 
-<RadzenTemplateForm Data=@("") Method="post" Action="/account/locallogin">
-    <RadzenLogin LoginText="@L["Login"]"
-    UserText="@L["UserName"]" UserRequired="@L.Required("DisplayName:UserName")"
-    PasswordText="@L["Password"]" PasswordRequired="@L.Required("DisplayName:Password")"
-    AllowResetPassword="false"
-    AllowRememberMe="true" RememberMe="true" RememberMeText="@L["RememberMe"]"
-    AllowRegister="@EnableLocalRegister" RegisterText="@L["Register"]" RegisterMessageText="@L["AreYouANewUser"]" Register="@OnRegister" />
-</RadzenTemplateForm>
+@if (!IsExternalLoginOnly)
+{
+    @if (EnableLocalLogin)
+    {
+        <RadzenTemplateForm Data=@("") Method="post" Action="/account/locallogin">
+            <RadzenLogin LoginText="@L["Login"]"
+            UserText="@L["UserName"]" UserRequired="@L.Required("DisplayName:UserName")"
+            PasswordText="@L["Password"]" PasswordRequired="@L.Required("DisplayName:Password")"
+            AllowResetPassword="false"
+            AllowRememberMe="true" RememberMe="true" RememberMeText="@L["RememberMe"]"
+            AllowRegister="@EnableLocalRegister" RegisterText="@L["Register"]" RegisterMessageText="@L["AreYouANewUser"]" Register="@OnRegister" />
+        </RadzenTemplateForm>
+    }
 
-<ExternalLoginProvider Text="@L["OrLoginWith"]" />
+    <ExternalLoginProvider Text="@(EnableLocalLogin ? L["OrLoginWith"] : "")" ReturnUrl="@ReturnUrl" />
+}
 
 @code {
     [SupplyParameterFromQuery]
     [Parameter]
     public string? Error { get; set; }
+
+    [SupplyParameterFromQuery]
+    [Parameter]
+    public bool SkipAutoLogin { get; set; }
+
+    [SupplyParameterFromQuery]
+    [Parameter]
+    public string? ReturnUrl { get; set; }
 
     [Inject]
     NavigationManager Navigation { get; set; } = default!;
@@ -31,7 +47,21 @@
     [Inject]
     ISettingProvider SettingProvider { get; set; } = default!;
 
+    [Inject]
+    IAuthenticationSchemeProvider SchemeProvider { get; set; } = default!;
+
+    [Inject]
+    IOptions<AbpRadzenUIOptions> RadzenUIOptions { get; set; } = default!;
+
     public bool EnableLocalRegister { get; set; }
+
+    public bool EnableLocalLogin { get; set; } = true;
+
+    List<ExternalProviderModel> ExternalProviders { get; set; } = [];
+
+    bool IsExternalLoginOnly => !EnableLocalLogin && ExternalProviders.Count == 1;
+
+    string? ExternalLoginScheme => IsExternalLoginOnly ? ExternalProviders.First().AuthenticationScheme : null;
 
     public Login()
     {
@@ -40,7 +70,10 @@
 
     protected override async Task OnInitializedAsync()
     {
+        EnableLocalLogin = await SettingProvider.IsTrueAsync(AccountSettingNames.EnableLocalLogin);
         EnableLocalRegister = await SettingProvider.IsTrueAsync(AccountSettingNames.IsSelfRegistrationEnabled);
+        ExternalProviders = await GetExternalProviders();
+
         await base.OnInitializedAsync();
 
         if (!string.IsNullOrWhiteSpace(Error))
@@ -51,7 +84,32 @@
         if (CurrentUser != null && CurrentUser.IsAuthenticated)
         {
             Navigation.NavigateTo("/");
+            return;
         }
+
+        if (IsExternalLoginOnly && !SkipAutoLogin)
+        {
+            var returnUrl = Uri.EscapeDataString(ReturnUrl ?? "/");
+            Navigation.NavigateTo($"/account/externallogin?provider={ExternalLoginScheme}&returnUrl={returnUrl}", forceLoad: true);
+            return;
+        }
+    }
+
+    async Task<List<ExternalProviderModel>> GetExternalProviders()
+    {
+        var schemes = await SchemeProvider.GetAllSchemesAsync();
+
+        return
+        [
+            .. schemes
+                .Where(x => x.DisplayName != null)
+                .Select(x => new ExternalProviderModel
+                {
+                    DisplayName = x.DisplayName,
+                    AuthenticationScheme = x.Name,
+                    IconPath = RadzenUIOptions.Value.ExternalLogin?.Providers?.FirstOrDefault(p => p.AuthenticationScheme == x.Name)?.IconPath ?? string.Empty
+                })
+        ];
     }
 
     public void OnRegister()

--- a/src/Abp.Blazor.Server.RadzenUI/Components/Pages/Account/Register.razor
+++ b/src/Abp.Blazor.Server.RadzenUI/Components/Pages/Account/Register.razor
@@ -66,7 +66,7 @@
 
 @if (!IsExternalLogin)
 {
-    <ExternalLoginProvider Text="@L["OrRegisterWith"]" />
+    <ExternalLoginProvider Text="@L["OrRegisterWith"]" ReturnUrl="@ReturnUrl" />
 }
 
 @code {
@@ -89,6 +89,10 @@
     [SupplyParameterFromQuery]
     [Parameter]
     public string EmailAddress { get; set; } = string.Empty;
+
+    [SupplyParameterFromQuery]
+    [Parameter]
+    public string? ReturnUrl { get; set; }
 
     [Inject]
     NavigationManager Navigation { get; set; } = default!;

--- a/src/Abp.Blazor.Server.RadzenUI/Components/Shared/ExternalLoginProvider.razor
+++ b/src/Abp.Blazor.Server.RadzenUI/Components/Shared/ExternalLoginProvider.razor
@@ -11,7 +11,7 @@
     @foreach (var provider in ExternalProviders)
     {
         <RadzenTemplateForm Data=@("") Method="post" Action="/account/externallogin" class="rz-mb-2">
-            <input type="hidden" name="returnUrl" value="/" />
+            <input type="hidden" name="returnUrl" value="@(ReturnUrl ?? "/")" />
             <input type="hidden" name="provider" value="@provider.AuthenticationScheme" />
             <RadzenButton ButtonType="ButtonType.Submit" Text="@provider.DisplayName" Style="width:100%"
             Image="@provider.IconPath" />
@@ -22,6 +22,9 @@
 @code {
     [Parameter]
     public string Text { get; set; } = string.Empty;
+
+    [Parameter]
+    public string? ReturnUrl { get; set; }
 
     [Inject]
     IAuthenticationSchemeProvider SchemeProvider { get; set; } = default!;

--- a/src/Abp.Blazor.Server.RadzenUI/Controllers/AccountController.cs
+++ b/src/Abp.Blazor.Server.RadzenUI/Controllers/AccountController.cs
@@ -62,6 +62,17 @@ public class AccountController(
     [HttpPost("/account/externallogin")]
     public async Task<IActionResult> ExternalLoginAsync(string provider, string returnUrl)
     {
+        return await ExternalLoginChallengeAsync(provider, returnUrl);
+    }
+
+    [HttpGet("/account/externallogin")]
+    public async Task<IActionResult> ExternalLoginGetAsync(string provider, string returnUrl)
+    {
+        return await ExternalLoginChallengeAsync(provider, returnUrl);
+    }
+
+    private async Task<IActionResult> ExternalLoginChallengeAsync(string provider, string returnUrl)
+    {
         try
         {
             var redirectUrl = Url.Action("ExternalLoginCallback", "Account", new { returnUrl });
@@ -220,7 +231,7 @@ public class AccountController(
     {
         await signInManager.SignOutAsync();
         await HttpContext.SignOutAsync();
-        return Redirect("~/account/login");
+        return Redirect("~/account/login?skipAutoLogin=true");
     }
 
     [HttpPost("/account/localregister")]


### PR DESCRIPTION
- Added EnableLocalLogin setting check
- Added ExternalProviders list and GetExternalProviders() method
- Added IsExternalLoginOnly computed property (!EnableLocalLogin && ExternalProviders.Count == 1)
- Added ExternalLoginScheme property to get the single provider's scheme
- Auto-redirects to external login when IsExternalLoginOnly is true
- Shows local login form only when EnableLocalLogin is true
- Shows external providers without "Or login with" text when local login is disabled

Behavior:
- When EnableLocalLogin = false AND exactly 1 external provider exists → auto-redirects to that provider
- When EnableLocalLogin = false AND multiple external providers exist → shows only external providers
- When EnableLocalLogin = true → shows local login form + external providers

Pass ReturnUrl to ExternalLoginProvider component